### PR TITLE
 remove unused header include in redis_slot.c

### DIFF
--- a/lib/redis_slot.c
+++ b/lib/redis_slot.c
@@ -1,6 +1,3 @@
-#include <lua.h>
-#include <lualib.h>
-#include <lauxlib.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>

--- a/resty-redis-cluster-1.0-1.rockspec
+++ b/resty-redis-cluster-1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "resty-redis-cluster"
 version = "1.0-1"
 source = {
-    url = "https://github.com/steve0511/resty-redis-cluster/"
+    url = "https://github.com/wangrzneu/resty-redis-cluster/"
 }
 description = {
     summary = "Openresty lua client for redis cluster",


### PR DESCRIPTION
Remove unused header include in redis_slot.c, then it can be compiled without Lua dependency.