### PR TITLE
(feat) add configuration parameter for dictionary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 
 ```lua
 local config = {
+    dict_name = "test_locks",               --shared dictionary name for locks
     name = "testCluster",                   --rediscluster name
     serv_list = {                           --redis cluster node list(host and port),
         { ip = "127.0.0.1", port = 7001 },

--- a/lib/rediscluster.lua
+++ b/lib/rediscluster.lua
@@ -5,6 +5,7 @@ local resty_lock = require "resty.lock"
 local setmetatable = setmetatable
 local tostring = tostring
 
+local DEFAULT_SHARED_DICT_NAME = "redis_cluster_slot_locks"
 local DEFAULT_MAX_REDIRECTION = 5
 local DEFAULT_KEEPALIVE_TIMEOUT = 55000
 local DEFAULT_KEEPALIVE_CONS = 1000
@@ -154,7 +155,7 @@ function _M.init_slots(self)
     if slot_cache[self.config.name] then
         return
     end
-    local lock, err = resty_lock:new("redis_cluster_slot_locks")
+    local lock, err = resty_lock:new(self.config.dict_name or DEFAULT_SHARED_DICT_NAME)
     if not lock then
         ngx.log(ngx.ERR, "failed to create lock in initialization slot cache: ", err)
         return


### PR DESCRIPTION
## Summary

Add configuration parameter to make shared dictionary name for locks to be configurable.
It would be really useful in case you already have created and using shared dictionary for locks with different name.