### PR TITLE
bug fix: wrong key served for slot calculation while processing command 'evalsha'

### DIFF
--- a/lib/rediscluster.lua
+++ b/lib/rediscluster.lua
@@ -284,7 +284,16 @@ local function handleCommandWithRetry(self, targetIp, targetPort, asking, cmd, k
     local config = self.config
 
     key = tostring(key)
-    local slot = redis_slot(key)
+
+    local slot_key = key
+    if cmd == 'evalsha' then
+        local t = {...}
+        if #t >= 2 then
+            slot_key = t[2]
+        end
+    end
+
+    local slot = redis_slot(slot_key)
 
     for k = 1, config.max_redirection or DEFAULT_MAX_REDIRECTION do
 


### PR DESCRIPTION
Reference issue #43 
This is caused by a wrong key for slot calculation is served at processing 'evalsha'. Thus the 'MOVED' action keeps moving to a wrong slot and reaches maximum redirection attempts at last.