### PR TITLE
fix(random) do not seed the random generator

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -273,9 +273,6 @@ function _M.new(self, config)
 end
 
 
-math.randomseed(os.time())
-
-
 local function pick_node(self, serv_list, slot, magicRadomSeed)
     local host
     local port


### PR DESCRIPTION
No library should ever seed the random generator, that is an application responsibility. Seeding it can cause very bad side effects if other components rely on proper random numbers.

Especially in this case, seeding it with time which is a very bad seed.