### PR TITLE
fix: allow cluster size to change

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 
 11. Also verified working properly in AWS elasticache.
 
+12. Allows rolling replacement of redis cluster.
+    Example) Redis Cluster with IPs 10.0.0.2, .3 and .4 is present. New nodes are introduced at IPs 10.0.0.5, .6 and .7. Slots are relocated fom node .2, .3 and .4 to .5, .6, and .7. The initial nodes can now be removed without downtime.
+
 ### installation
 
 1. please compile and generate redis_slot.so from redis_slot.c (can done by gcc)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 11. Also verified working properly in AWS elasticache.
 
 12. Allows rolling replacement of redis cluster.
-    Example) Redis Cluster with IPs 10.0.0.2, .3 and .4 is present. New nodes are introduced at IPs 10.0.0.5, .6 and .7. Slots are relocated fom node .2, .3 and .4 to .5, .6, and .7. The initial nodes can now be removed without downtime.
+    Example) Redis Cluster with IPs 10.0.0.2, .3 and .4 is present. New nodes are introduced at IPs 10.0.0.5, .6 and .7. Slots are relocated fom node .2, .3 and .4 to .5, .6, and .7. The initial nodes can now be removed without downtime in nginx, since the initial configuration is not used anymore.
 
 ### installation
 
@@ -54,7 +54,6 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 3. nginx.conf add config:
 
    lua_shared_dict redis_cluster_slot_locks 100k;
-   lua_shared_dict redis_cluster_serv_list_locks 100k;
 
 ### Sample usage
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 3. nginx.conf add config:
 
    lua_shared_dict redis_cluster_slot_locks 100k;
+   lua_shared_dict redis_cluster_serv_list_locks 100k;
 
 ### Sample usage
 

--- a/lib/rediscluster.lua
+++ b/lib/rediscluster.lua
@@ -218,35 +218,6 @@ function _M.init_slots(self)
     end
 end
 
-function _M.init_serv_list(self)
-    if slot_cache[self.config.name .. "serv_list"] then
-        return
-    end
-    local lock, err = resty_lock:new("redis_cluster_serv_list_locks")
-    if not lock then
-        ngx.log(ngx.ERR, "failed to create lock in initialization serv_list cache: ", err)
-        return
-    end
-
-    local elapsed, err = lock:lock("redis_cluster_serv_list_locks" .. self.config.name)
-    if not elapsed then
-        ngx.log(ngx.ERR, "failed to acquire the lock in initialization serv_list cache: ", err)
-        return
-    end
-
-    if slot_cache[self.config.name .. "serv_list"] then
-        local ok, err = lock:unlock()
-        if not ok then
-            ngx.log(ngx.ERR, "failed to unlock in initialization serv_list cache: ", err)
-        end
-        return
-    end
-
-    local ok, err = lock:unlock()
-    if not ok then
-        ngx.log(ngx.ERR, "failed to unlock in initialization serv_list cache:", err)
-    end
-end
 
 
 function _M.new(self, config)
@@ -257,9 +228,6 @@ function _M.new(self, config)
         return nil, " redis cluster config serv_list is empty"
     end
     
-    local serv_list_inst = { config = config }
-    serv_list_inst = setmetatable(serv_list_inst, mt)
-    serv_list_inst:init_serv_list()
 
     local inst = { config = config }
     inst = setmetatable(inst, mt)

--- a/lib/rediscluster.lua
+++ b/lib/rediscluster.lua
@@ -116,8 +116,8 @@ local function try_hosts_slots(self, serv_list)
         local ip = serv_list[i].ip
         local port = serv_list[i].port
         local redis_client = redis:new()
-        local ok, err = redis_client:connect(ip, port)
         redis_client:set_timeout(config.connection_timout or DEFAULT_CONNECTION_TIMEOUT)
+        local ok, err = redis_client:connect(ip, port)
         if ok then
             local authok, autherr = checkAuth(self, redis_client)
             if autherr then

--- a/lib/rediscluster.lua
+++ b/lib/rediscluster.lua
@@ -464,7 +464,6 @@ local function handleCommandWithRetry(self, targetIp, targetPort, asking, cmd, k
         else
             --There might be node fail, we should also refresh slot cache
             self:fetch_slots()
-            ngx.log(ngx.NOTICE, "got " .. connerr .. ". Will not return error but will allow retry")
             if k == config.max_redirection or k == DEFAULT_MAX_REDIRECTION then
                 -- only return after allowing for `k` attempts
                 return nil, connerr

--- a/lib/rediscluster.lua
+++ b/lib/rediscluster.lua
@@ -568,6 +568,9 @@ function _M.commit_pipeline(self)
     local needToRetry = false
 
     local slots = slot_cache[config.name]
+    if slots == nil then
+        return nil, "not slots information present, nginx might have never successfully executed cluster(\"slots\")"
+    end
 
     local node_res_map = {}
 
@@ -581,6 +584,9 @@ function _M.commit_pipeline(self)
         _reqs[i].origin_index = i
         local key = _reqs[i].key
         local slot = redis_slot(tostring(key))
+        if slots[slot] == nil then
+            return nil, "not slots information present, nginx might have never successfully executed cluster(\"slots\")"
+        end
         local slot_item = slots[slot]
 
         local ip, port, slave, err = pick_node(self, slot_item.serv_list, slot, magicRandomPickupSeed)


### PR DESCRIPTION
current code does not allow for a redis cluster memembers to change outside of the self.config.serv_list. This code adds a dynamic list where the servers from cluster(slots) are used instead of self.config.serv_list