### PR TITLE
fix(config) a typo in timeout (timout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ local config = {
     },
     keepalive_timeout = 60000,              --redis connection pool idle timeout
     keepalive_cons = 1000,                  --redis connection pool size
-    connection_timout = 1000,               --timeout while connecting
+    connection_timeout = 1000,              --timeout while connecting
     max_redirection = 5,                    --maximum retry attempts for redirection
     max_connection_attempts = 1             --maximum retry attempts for connection
 }
@@ -103,7 +103,7 @@ local config = {
     },
     keepalive_timeout = 60000,              --redis connection pool idle timeout
     keepalive_cons = 1000,                  --redis connection pool size
-    connection_timout = 1000,               --timeout while connecting
+    connection_timeout = 1000,              --timeout while connecting
     max_redirection = 5,                    --maximum retry attempts for redirection,
     max_connection_attempts = 1,            --maximum retry attempts for connection
     auth = "pass"                           --set password while setting auth
@@ -137,7 +137,7 @@ local config = {
     },
     keepalive_timeout = 60000,
     keepalive_cons = 1000,
-    connection_timout = 1000,
+    connection_timeout = 1000,
     max_redirection = 5,
     max_connection_attempts = 1
 }
@@ -184,8 +184,8 @@ local config = {
     },
     keepalive_timeout = 60000,
     keepalive_cons = 1000,
-    connection_timout = 1000,
-    max_redirection = 5
+    connection_timeout = 1000,
+    max_redirection = 5,
     max_connection_attempts = 1
 }
 
@@ -217,7 +217,7 @@ local config = {
     },
     keepalive_timeout = 60000,
     keepalive_cons = 1000,
-    connection_timout = 1000,
+    connection_timeout = 1000,
     max_redirection = 5,
     max_connection_attempts = 1
 }
@@ -255,7 +255,7 @@ local config = {
     },
     keepalive_timeout = 60000,              --redis connection pool idle timeout
     keepalive_cons = 1000,                  --redis connection pool size
-    connection_timout = 1000,               --timeout while connecting
+    connection_timeout = 1000,              --timeout while connecting
     max_redirection = 5,                    --maximum retry attempts for redirection
     max_connection_attempts = 1             --maximum retry attempts for connection
 }

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -81,7 +81,9 @@ local function try_hosts_slots(self, serv_list)
         local port = serv_list[i].port
         local redis_client = redis:new()
         local ok, err
-        redis_client:set_timeout(config.connection_timout or DEFAULT_CONNECTION_TIMEOUT)
+        redis_client:set_timeout(config.connection_timeout or
+                                 config.connection_timout  or
+                                 DEFAULT_CONNECTION_TIMEOUT)
 
         --attempt to connect DEFAULT_MAX_CONNECTION_ATTEMPTS times to redis
         for k = 1, config.max_connection_attempts or DEFAULT_MAX_CONNECTION_ATTEMPTS do
@@ -349,7 +351,9 @@ local function handleCommandWithRetry(self, targetIp, targetPort, asking, cmd, k
         end
 
         local redis_client = redis:new()
-        redis_client:set_timeout(config.connection_timout or DEFAULT_CONNECTION_TIMEOUT)
+        redis_client:set_timeout(config.connection_timeout or
+                                 config.connection_timout  or
+                                 DEFAULT_CONNECTION_TIMEOUT)
         local ok, connerr = redis_client:connect(ip, port)
 
         if ok then
@@ -576,7 +580,9 @@ function _M.commit_pipeline(self)
         local reqs = v.reqs
         local slave = v.slave
         local redis_client = redis:new()
-        redis_client:set_timeout(config.connection_timout or DEFAULT_CONNECTION_TIMEOUT)
+        redis_client:set_timeout(config.connection_timeout or
+                                 config.connection_timout  or
+                                 DEFAULT_CONNECTION_TIMEOUT)
         local ok, err = redis_client:connect(ip, port)
 
         local authok, autherr = checkAuth(self, redis_client)


### PR DESCRIPTION
### Summary

There is a setting called `connection_timout` that is missing `e`.

This commit fixes that issue, but keeps it backward compatible.