### PR TITLE
(feat) support granular connection timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ local config = {
     keepalive_timeout = 60000,              --redis connection pool idle timeout
     keepalive_cons = 1000,                  --redis connection pool size
     connection_timeout = 1000,              --timeout while connecting
+    read_timeout = 1000,                    --timeout while reading
+    send_timeout = 1000,                    --timeout while sending
     max_redirection = 5,                    --maximum retry attempts for redirection,
     max_connection_attempts = 1,            --maximum retry attempts for connection
     auth = "pass"                           --set password while setting auth
@@ -139,6 +141,8 @@ local config = {
     keepalive_timeout = 60000,
     keepalive_cons = 1000,
     connection_timeout = 1000,
+    read_timeout = 1000,
+    send_timeout = 1000,
     max_redirection = 5,
     max_connection_attempts = 1
 }
@@ -186,6 +190,8 @@ local config = {
     keepalive_timeout = 60000,
     keepalive_cons = 1000,
     connection_timeout = 1000,
+    read_timeout = 1000,
+    send_timeout = 1000,
     max_redirection = 5,
     max_connection_attempts = 1
 }
@@ -219,6 +225,8 @@ local config = {
     keepalive_timeout = 60000,
     keepalive_cons = 1000,
     connection_timeout = 1000,
+    read_timeout = 1000,
+    send_timeout = 1000,
     max_redirection = 5,
     max_connection_attempts = 1
 }
@@ -257,6 +265,8 @@ local config = {
     keepalive_timeout = 60000,              --redis connection pool idle timeout
     keepalive_cons = 1000,                  --redis connection pool size
     connection_timeout = 1000,              --timeout while connecting
+    read_timeout = 1000,                    --timeout while reading
+    send_timeout = 1000,                    --timeout while sending
     max_redirection = 5,                    --maximum retry attempts for redirection
     max_connection_attempts = 1             --maximum retry attempts for connection
 }

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -46,6 +46,8 @@ __DATA__
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
                             connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -110,6 +112,8 @@ dog: an animal
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
                             connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -219,6 +223,8 @@ not_found not found.
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
                             connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -284,6 +290,8 @@ get nokey: 0 (table)
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
                             connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -401,6 +409,8 @@ connections: 1
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
                             connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -447,6 +457,8 @@ failed to set connections: nil: ERR wrong number of arguments for 'incr' command
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
                             connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -518,7 +530,9 @@ lrange result: ["hello","world"]
                                         },
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
-                            connection_timout = 2500,               --timeout while connecting
+                            connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 2500,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -563,7 +577,7 @@ no element popped.
 [error]
 --- timeout: 3
 
-=== TEST 9: blpop expires cosocket timeout
+=== TEST 9: blpop expires cosocket read timeout
 --- http_config eval: $::HttpConfig
 --- config
     location /t {
@@ -581,7 +595,9 @@ no element popped.
                                         },
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
-                            connection_timout = 200,               --timeout while connecting
+                            connection_timout = 200,                --timeout while connecting
+                            read_timeout = 200,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -643,7 +659,9 @@ lua tcp socket read timed out
                                         },
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
-                            connection_timout = 200,               --timeout while connecting
+                            connection_timout = 1000,                --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -708,7 +726,9 @@ mget result: ["an animal",null,"an animal"]
                                         },
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
-                            connection_timout = 200,               --timeout while connecting
+                            connection_timout = 200,                --timeout while connecting
+                            read_timeout = 200,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -801,7 +821,9 @@ cow: moo
                                         },
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
-                            connection_timout = 1000,                --timeout while connecting
+                            connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 1000,                    --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }
@@ -883,7 +905,9 @@ foo: false, type: string
                                         },
                             keepalive_timeout = 60000,              --redis connection pool idle timeout
                             keepalive_cons = 1000,                  --redis connection pool size
-                            connection_timout = 200,               --timeout while connecting
+                            connection_timout = 1000,               --timeout while connecting
+                            read_timeout = 200,                     --timeout while reading
+                            send_timeout = 1000,                    --timeout while sending
                             max_redirection = 5                     --maximum retry attempts for redirection
                             
             }


### PR DESCRIPTION
As per [lua-resty-redis's docs](https://github.com/openresty/lua-resty-redis#set_timeouts) `set_timeouts` should be preferred over `set_timeout` 

All tests are passing
```
docker run -d --rm  -e "IP=0.0.0.0" -p 7000-7006:7000-7006 grokzen/redis-cluster:latest && sleep 10 && make test
e0b1a05315e88dbf86f4449c612bb6359a6b8ed76ea0626ecad0f665a6d7d025
PATH=/<***prefix***>/nginx/sbin:$PATH prove -I../test-nginx/lib -r t
t/sanity.t .. ok
All tests successful.
Files=1, Tests=78, 13 wallclock secs ( 0.03 usr  0.02 sys +  0.50 cusr  0.80 csys =  1.35 CPU)
Result: PASS
```