### PR TITLE
fix: return true on first succesful iteration of try_hosts_slots logic

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -180,6 +180,12 @@ local function try_hosts_slots(self, serv_list)
                 table_insert(errors, nerr)
             end
             release_connection(redis_client, config)
+            
+            -- refresh of slots and master nodes successful
+            -- not required to connect/iterate over additional hosts
+            if nodes_res and slots_info then
+                return true, nil
+            end
         else
             table_insert(errors, err)
         end


### PR DESCRIPTION
closes #58 

Error in the current `try_hosts_slots` method, as any error will result in the method returning an error, even if the method was later successful. 

This changes the method to return once a complete slots and cache of masters operations has been performed.