### PR TITLE
Fix for max_connection_timeout in worker/timer context

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -98,7 +98,7 @@ local function split(s, delimiter)
 end
 
 local function try_hosts_slots(self, serv_list)
-    local start_time = ngx.req.start_time()
+    local start_time = ngx.now()
     local errors = {}
     local config = self.config
     if #serv_list < 1 then


### PR DESCRIPTION
`ngx.req.start_time` is not available when using this client in the worker/timer context.

In this case `ngx.req.start_time()` always returns 0 and `max_connection_timeout` always triggers a timeout without even attempting a connection