### PR TITLE
Ensure configured serv_list is available when fetching slots

### DIFF
--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -214,12 +214,19 @@ function _M.fetch_slots(self)
     local serv_list = self.config.serv_list
     local serv_list_cached = slot_cache[self.config.name .. "serv_list"]
 
-    local serv_list_combined = {}
+    local serv_list_combined
 
-    -- if a cached serv_list is present, use it
+    -- if a cached serv_list is present, start with that
     if serv_list_cached then
         serv_list_combined = serv_list_cached.serv_list
+
+        -- then append the serv_list from config, in the event that the entire
+        -- cached serv_list no longer points to anything usable
+        for _, s in ipairs(serv_list) do
+            table_insert(serv_list_combined, s)
+        end
     else
+        -- otherwise we bootstrap with our serv_list from config
         serv_list_combined = serv_list
     end
 


### PR DESCRIPTION
Previously, if a cached serv_list existed then these would be the only
servers consulted. However, it is possible that the config serv_list has
been updated which means any new addresses will not be considered.

In most scenarios this is not a problem - the cluster knows the current
active topology. But in the event that all nodes are suddenly lost (for
example, the entire cluster is brought up on new addresses), the cache
presumes itself to still be the source of truth.

This commit appends our configured serv_list to the cached list (if
present), and so if all cached servers fail, it will try from the
configured list.
