### PR TITLE
Fix endless moved redirections, connection leak and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 2. nginx.conf add config:
 
    lua_shared_dict redis_cluster_slot_locks 100k;
+   lua_shared_dict redis_cluster_slots_info 100k;
    
-3. or install by luarock, link: https://luarocks.org/modules/steve0511/resty-redis-cluster 
+4. or install by luarock, link: https://luarocks.org/modules/steve0511/resty-redis-cluster 
 
 ### Sample usage
 
@@ -61,10 +62,11 @@ While building the client, thanks for https://github.com/cuiweixie/lua-resty-red
 
 ```lua
 local config = {
-    dict_name = "test_locks",               --shared dictionary name for locks, if default value is not used 
-    refresh_lock_key = "refresh_lock",      --shared dictionary name prefix for lock of each worker, if default value is not used 
-    name = "testCluster",                   --rediscluster name
-    serv_list = {                           --redis cluster node list(host and port),
+    dict_name = "test_locks",                 --shared dictionary name for locks, if default value is not used
+    refresh_lock_key = "refresh_lock",        --shared dictionary name prefix for lock of each worker, if default value is not used
+    slots_info_dict_name = "test_slots_info", --shared dictionary name for slots_info
+    name = "testCluster",                     --rediscluster name
+    serv_list = {                             --redis cluster node list (host and port)
         { ip = "127.0.0.1", port = 7001 },
         { ip = "127.0.0.1", port = 7002 },
         { ip = "127.0.0.1", port = 7003 },
@@ -72,11 +74,11 @@ local config = {
         { ip = "127.0.0.1", port = 7005 },
         { ip = "127.0.0.1", port = 7006 }
     },
-    keepalive_timeout = 60000,              --redis connection pool idle timeout
-    keepalive_cons = 1000,                  --redis connection pool size
-    connect_timeout = 1000,              --timeout while connecting
-    max_redirection = 5,                    --maximum retry attempts for redirection
-    max_connection_attempts = 1             --maximum retry attempts for connection
+    keepalive_timeout = 60000,                --redis connection pool idle timeout
+    keepalive_cons = 1000,                    --redis connection pool size
+    connect_timeout = 1000,                   --timeout while connecting
+    max_redirection = 5,                      --maximum retry attempts for redirection
+    max_connection_attempts = 1               --maximum retry attempts for connection
 }
 
 local redis_cluster = require "rediscluster"
@@ -93,10 +95,11 @@ end
   
 ```lua
 local config = {
-    dict_name = "test_locks",               --shared dictionary name for locks, if default value is not used 
-    refresh_lock_key = "refresh_lock",      --shared dictionary name prefix for lock of each worker, if default value is not used 
-    name = "testCluster",                   --rediscluster name
-    serv_list = {                           --redis cluster node list(host and port),
+    dict_name = "test_locks",                 --shared dictionary name for locks, if default value is not used
+    refresh_lock_key = "refresh_lock",        --shared dictionary name prefix for lock of each worker, if default value is not used
+    name = "testCluster",                     --rediscluster name
+    slots_info_dict_name = "test_slots_info", --shared dictionary name for slots_info
+    serv_list = {                             --redis cluster node list (host and port)
         { ip = "127.0.0.1", port = 7001 },
         { ip = "127.0.0.1", port = 7002 },
         { ip = "127.0.0.1", port = 7003 },
@@ -104,14 +107,14 @@ local config = {
         { ip = "127.0.0.1", port = 7005 },
         { ip = "127.0.0.1", port = 7006 }
     },
-    keepalive_timeout = 60000,              --redis connection pool idle timeout
-    keepalive_cons = 1000,                  --redis connection pool size
-    connect_timeout = 1000,              --timeout while connecting
-    read_timeout = 1000,                    --timeout while reading
-    send_timeout = 1000,                    --timeout while sending
-    max_redirection = 5,                    --maximum retry attempts for redirection,
-    max_connection_attempts = 1,            --maximum retry attempts for connection
-    auth = "pass"                           --set password while setting auth
+    keepalive_timeout = 60000,                --redis connection pool idle timeout
+    keepalive_cons = 1000,                    --redis connection pool size
+    connect_timeout = 1000,                   --timeout while connecting
+    read_timeout = 1000,                      --timeout while reading
+    send_timeout = 1000,                      --timeout while sending
+    max_redirection = 5,                      --maximum retry attempts for redirection
+    max_connection_attempts = 1,              --maximum retry attempts for connection
+    auth = "pass"                             --set password while setting auth
 }
 
 local redis_cluster = require "rediscluster"
@@ -131,8 +134,9 @@ end
 local cjson = require "cjson"
 
 local config = {
-    dict_name = "test_locks",               --shared dictionary name for locks, if default value is not used 
-    refresh_lock_key = "refresh_lock",      --shared dictionary name prefix for lock of each worker, if default value is not used 
+    dict_name = "test_locks",                 --shared dictionary name for locks, if default value is not used
+    refresh_lock_key = "refresh_lock",        --shared dictionary name prefix for lock of each worker, if default value is not used
+    slots_info_dict_name = "test_slots_info", --shared dictionary name for slots_info
     name = "testCluster",
     serv_list = {
         { ip = "127.0.0.1", port = 7001 },
@@ -181,8 +185,9 @@ end
 local cjson = require "cjson"
 
 local config = {
-    dict_name = "test_locks",               --shared dictionary name for locks, if default value is not used 
-    refresh_lock_key = "refresh_lock",      --shared dictionary name prefix for lock of each worker, if default value is not used 
+    dict_name = "test_locks",                 --shared dictionary name for locks, if default value is not used
+    refresh_lock_key = "refresh_lock",        --shared dictionary name prefix for lock of each worker, if default value is not used
+    slots_info_dict_name = "test_slots_info", --shared dictionary name for slots_info
     name = "testCluster",
     enable_slave_read = true,
     serv_list = {
@@ -218,8 +223,9 @@ end
 local cjson = require "cjson"
 
 local config = {
-    dict_name = "test_locks",               --shared dictionary name for locks, if default value is not used 
-    refresh_lock_key = "refresh_lock",      --shared dictionary name prefix for lock of each worker, if default value is not used 
+    dict_name = "test_locks",                 --shared dictionary name for locks, if default value is not used
+    refresh_lock_key = "refresh_lock",        --shared dictionary name prefix for lock of each worker, if default value is not used
+    slots_info_dict_name = "test_slots_info", --shared dictionary name for slots_info
     name = "testCluster",
     enable_slave_read = true,
     serv_list = {
@@ -261,10 +267,11 @@ end
 
 ```lua
 local config = {
-    dict_name = "test_locks",               --shared dictionary name for locks, if default value is not used 
-    refresh_lock_key = "refresh_lock",      --shared dictionary name prefix for lock of each worker, if default value is not used 
-    name = "testCluster",                   --rediscluster name
-    serv_list = {                           --redis cluster node list(host and port),
+    dict_name = "test_locks",                 --shared dictionary name for locks, if default value is not used
+    refresh_lock_key = "refresh_lock",        --shared dictionary name prefix for lock of each worker, if default value is not used
+    slots_info_dict_name = "test_slots_info", --shared dictionary name for slots_info
+    name = "testCluster",                     --rediscluster name
+    serv_list = {                             --redis cluster node list (host and port)
         { ip = "127.0.0.1", port = 7001 },
         { ip = "127.0.0.1", port = 7002 },
         { ip = "127.0.0.1", port = 7003 },
@@ -272,13 +279,13 @@ local config = {
         { ip = "127.0.0.1", port = 7005 },
         { ip = "127.0.0.1", port = 7006 }
     },
-    keepalive_timeout = 60000,              --redis connection pool idle timeout
-    keepalive_cons = 1000,                  --redis connection pool size
-    connect_timeout = 1000,              --timeout while connecting
-    read_timeout = 1000,                    --timeout while reading
-    send_timeout = 1000,                    --timeout while sending
-    max_redirection = 5,                    --maximum retry attempts for redirection
-    max_connection_attempts = 1             --maximum retry attempts for connection
+    keepalive_timeout = 60000,                --redis connection pool idle timeout
+    keepalive_cons = 1000,                    --redis connection pool size
+    connect_timeout = 1000,                   --timeout while connecting
+    read_timeout = 1000,                      --timeout while reading
+    send_timeout = 1000,                      --timeout while sending
+    max_redirection = 5,                      --maximum retry attempts for redirection
+    max_connection_attempts = 1               --maximum retry attempts for connection
 }
 
 local redis_cluster = require "rediscluster"
@@ -298,10 +305,11 @@ end
 
 ```lua
 local config = {
-    dict_name = "test_locks",               --shared dictionary name for locks, if default value is not used 
-    refresh_lock_key = "refresh_lock",      --shared dictionary name prefix for lock of each worker, if default value is not used 
-    name = "testCluster",                   --rediscluster name
-    serv_list = {                           --redis cluster node list(host and port),
+    dict_name = "test_locks",                 --shared dictionary name for locks, if default value is not used
+    refresh_lock_key = "refresh_lock",        --shared dictionary name prefix for lock of each worker, if default value is not used
+    slots_info_dict_name = "test_slots_info", --shared dictionary name for slots_info
+    name = "testCluster",                     --rediscluster name
+    serv_list = {                             --redis cluster node list (host and port)
         { ip = "127.0.0.1", port = 7001 },
         { ip = "127.0.0.1", port = 7002 },
         { ip = "127.0.0.1", port = 7003 },
@@ -309,11 +317,11 @@ local config = {
         { ip = "127.0.0.1", port = 7005 },
         { ip = "127.0.0.1", port = 7006 }
     },
-    keepalive_timeout = 60000,              --redis connection pool idle timeout
-    keepalive_cons = 1000,                  --redis connection pool size
-    connect_timeout = 1000,              --timeout while connecting
-    max_redirection = 5,                    --maximum retry attempts for redirection
-    max_connection_attempts = 1,             --maximum retry attempts for connection
+    keepalive_timeout = 60000,                --redis connection pool idle timeout
+    keepalive_cons = 1000,                    --redis connection pool size
+    connect_timeout = 1000,                   --timeout while connecting
+    max_redirection = 5,                      --maximum retry attempts for redirection
+    max_connection_attempts = 1,              --maximum retry attempts for connection
     connect_opts = {
         ssl = true,
         ssl_verify = true,

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -369,7 +369,7 @@ local function parse_signal(res, prefix)
         if type(res) == "table" then
             for i = 1, #res do
                 if type(res[i]) == "string" and string.sub(res[i], 1, #prefix) == prefix then
-                    local matched = ngx.re.match(string.sub(#prefix + 1), "^ [^ ]+ ([^:]+):([^ ]+)", "jo", nil, nil)
+                    local matched = ngx.re.match(string.sub(res[i], #prefix + 1), "^ [^ ]+ ([^:]+):([^ ]+)", "jo", nil, nil)
                     if not matched then
                         ngx.log(ngx.ERR, "failed to parse redirection host and port. msg is: ", res[i])
                         return nil, nil, "failed to parse redirection host and port"

--- a/lib/resty/rediscluster.lua
+++ b/lib/resty/rediscluster.lua
@@ -40,7 +40,6 @@ local function parse_key(key_str)
     end
 end
 
-
 local _M = {}
 
 local mt = { __index = _M }
@@ -75,26 +74,72 @@ local function check_auth(self, redis_client)
         else
             return nil, err
         end
-
     else
         return true, nil
     end
 end
 
 local function release_connection(red, config)
-    local ok,err = red:set_keepalive(config.keepalive_timeout
+    local ok, err = red:set_keepalive(config.keepalive_timeout
             or DEFAULT_KEEPALIVE_TIMEOUT, config.keepalive_cons or DEFAULT_KEEPALIVE_CONS)
     if not ok then
-        ngx.log(ngx.ERR,"set keepalive failed:", err)
+        ngx.log(ngx.ERR, "set keepalive failed: ", err)
     end
 end
 
 local function split(s, delimiter)
     local result = {};
-    for m in (s..delimiter):gmatch("(.-)"..delimiter) do
+    for m in (s .. delimiter):gmatch("(.-)" .. delimiter) do
         table_insert(result, m);
     end
     return result;
+end
+
+local function update_slots_and_servers(self, slots_info)
+    local slots = {}
+    -- while slots are updated, create a list of servers present in cluster
+    -- this can differ from self.config.serv_list if a cluster is resized (added/removed nodes)
+    local servers = { serv_list = {} }
+    for n = 1, #slots_info do
+        local sub_info = slots_info[n]
+        --slot info item 1 and 2 are the subrange start end slots
+        local start_slot, end_slot = sub_info[1], sub_info[2]
+
+        -- generate new list of servers
+        for j = 3, #sub_info do
+            servers.serv_list[#servers.serv_list + 1] = { ip = sub_info[j][1], port = sub_info[j][2] }
+        end
+
+        for slot = start_slot, end_slot do
+            local list = { serv_list = {} }
+            --from 3, here lists the host/port/nodeid of in charge nodes
+            for j = 3, #sub_info do
+                list.serv_list[#list.serv_list + 1] = { ip = sub_info[j][1], port = sub_info[j][2] }
+                slots[slot] = list
+            end
+        end
+    end
+
+    --ngx.log(ngx.NOTICE, "finished initializing slotcache...")
+    slot_cache[self.config.name] = slots
+    slot_cache[self.config.name .. "serv_list"] = servers
+end
+
+local function cache_master_nodes(nodes_res)
+    local nodes_info = split(nodes_res, char(10))
+    for _, node in ipairs(nodes_info) do
+        local node_info = split(node, " ")
+        if #node_info > 2 then
+            local is_master = match(node_info[3], "master") ~= nil
+            if is_master then
+                local ip_port = split(split(node_info[2], "@")[1], ":")
+                table_insert(master_nodes, {
+                    ip = ip_port[1],
+                    port = tonumber(ip_port[2])
+                })
+            end
+        end
+    end
 end
 
 local function try_hosts_slots(self, serv_list)
@@ -111,8 +156,8 @@ local function try_hosts_slots(self, serv_list)
         local redis_client = redis:new()
         local ok, err, max_connection_timeout_err
         redis_client:set_timeouts(config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
-                                  config.send_timeout or DEFAULT_SEND_TIMEOUT,
-                                  config.read_timeout or DEFAULT_READ_TIMEOUT)
+                config.send_timeout or DEFAULT_SEND_TIMEOUT,
+                config.read_timeout or DEFAULT_READ_TIMEOUT)
 
         --attempt to connect DEFAULT_MAX_CONNECTION_ATTEMPTS times to redis
         for k = 1, config.max_connection_attempts or DEFAULT_MAX_CONNECTION_ATTEMPTS do
@@ -125,9 +170,11 @@ local function try_hosts_slots(self, serv_list)
             end
 
             ok, err = redis_client:connect(ip, port, self.config.connect_opts)
-            if ok then break end
+            if ok then
+                break
+            end
             if err then
-                ngx.log(ngx.ERR,"unable to connect, attempt nr ", k, " : error: ", err)
+                ngx.log(ngx.ERR, "unable to connect, attempt number ", k, ", error: ", err)
                 table_insert(errors, err)
             end
         end
@@ -138,55 +185,19 @@ local function try_hosts_slots(self, serv_list)
                 table_insert(errors, autherr)
                 return nil, errors
             end
+
             local slots_info
             slots_info, err = redis_client:cluster("slots")
             if slots_info then
-                local slots = {}
-                -- while slots are updated, create a list of servers present in cluster
-                -- this can differ from self.config.serv_list if a cluster is resized (added/removed nodes)
-                local servers = { serv_list = {} }
-                for n = 1, #slots_info do
-                    local sub_info = slots_info[n]
-                    --slot info item 1 and 2 are the subrange start end slots
-                    local start_slot, end_slot = sub_info[1], sub_info[2]
-
-                    -- generate new list of servers
-                    for j = 3, #sub_info do
-                      servers.serv_list[#servers.serv_list + 1 ] = { ip = sub_info[j][1], port = sub_info[j][2] }
-                    end
-
-                    for slot = start_slot, end_slot do
-                        local list = { serv_list = {} }
-                        --from 3, here lists the host/port/nodeid of in charge nodes
-                        for j = 3, #sub_info do
-                            list.serv_list[#list.serv_list + 1] = { ip = sub_info[j][1], port = sub_info[j][2] }
-                            slots[slot] = list
-                        end
-                    end
-                end
-                --ngx.log(ngx.NOTICE, "finished initializing slotcache...")
-                slot_cache[self.config.name] = slots
-                slot_cache[self.config.name .. "serv_list"] = servers
+                update_slots_and_servers(self, slots_info)
             else
                 table_insert(errors, err)
             end
+
             -- cache master nodes
             local nodes_res, nerr = redis_client:cluster("nodes")
             if nodes_res then
-                local nodes_info = split(nodes_res, char(10))
-                for _, node in ipairs(nodes_info) do
-                    local node_info = split(node, " ")
-                    if #node_info > 2 then
-                        local is_master = match(node_info[3], "master") ~= nil
-                        if is_master then
-                            local ip_port = split(split(node_info[2], "@")[1], ":")
-                            table_insert(master_nodes, {
-                                ip = ip_port[1],
-                                port = tonumber(ip_port[2])
-                            })
-                        end
-                    end
-                end
+                cache_master_nodes(nodes_res)
             else
                 table_insert(errors, nerr)
             end
@@ -209,11 +220,9 @@ local function try_hosts_slots(self, serv_list)
     return nil, errors
 end
 
-
 function _M.fetch_slots(self)
     local serv_list = self.config.serv_list
     local serv_list_cached = slot_cache[self.config.name .. "serv_list"]
-
     local serv_list_combined
 
     -- if a cached serv_list is present, start with that
@@ -240,11 +249,11 @@ function _M.fetch_slots(self)
     end
 end
 
-
 function _M.refresh_slots(self)
     local worker_id = ngx.worker.id()
     local lock, err, elapsed, ok
-    lock, err = resty_lock:new(self.config.dict_name or DEFAULT_SHARED_DICT_NAME, {time_out = 0})
+    lock, err = resty_lock:new(self.config.dict_name or DEFAULT_SHARED_DICT_NAME, { time_out = 0 })
+
     if not lock then
         ngx.log(ngx.ERR, "failed to create lock in refresh slot cache: ", err)
         return nil, err
@@ -253,23 +262,23 @@ function _M.refresh_slots(self)
     local refresh_lock_key = (self.config.refresh_lock_key or DEFAULT_REFRESH_DICT_NAME) .. worker_id
     elapsed, err = lock:lock(refresh_lock_key)
     if not elapsed then
-        return nil, 'race refresh lock fail, ' .. err
+        return nil, "race refresh lock fail, " .. err
     end
 
     self:fetch_slots()
     ok, err = lock:unlock()
     if not ok then
-        ngx.log(ngx.ERR, "failed to unlock in refresh slot cache:", err)
+        ngx.log(ngx.ERR, "failed to unlock in refresh slot cache: ", err)
         return nil, err
     end
 end
-
 
 function _M.init_slots(self)
     if slot_cache[self.config.name] then
         -- already initialized
         return true
     end
+
     local ok, lock, elapsed, err
     lock, err = resty_lock:new(self.config.dict_name or DEFAULT_SHARED_DICT_NAME)
     if not lock then
@@ -296,28 +305,26 @@ function _M.init_slots(self)
     if errs then
         ok, err = lock:unlock()
         if not ok then
-            ngx.log(ngx.ERR, "failed to unlock in initialization slot cache:", err)
+            ngx.log(ngx.ERR, "failed to unlock in initialization slot cache: ", err)
         end
         return nil, errs
     end
+
     ok, err = lock:unlock()
     if not ok then
-        ngx.log(ngx.ERR, "failed to unlock in initialization slot cache:", err)
+        ngx.log(ngx.ERR, "failed to unlock in initialization slot cache: ", err)
     end
     -- initialized
     return true
 end
 
-
-
 function _M.new(_, config)
     if not config.name then
-        return nil, " redis cluster config name is empty"
+        return nil, "redis cluster config name is empty"
     end
     if not config.serv_list or #config.serv_list < 1 then
-        return nil, " redis cluster config serv_list is empty"
+        return nil, "redis cluster config serv_list is empty"
     end
-
 
     local inst = { config = config }
     inst = setmetatable(inst, mt)
@@ -328,15 +335,12 @@ function _M.new(_, config)
     return inst
 end
 
-
 local function pick_node(self, serv_list, slot, magic_radom_seed)
-    local host
-    local port
-    local slave
-    local index
+    local host, port, slave, index
     if #serv_list < 1 then
         return nil, nil, nil, "serv_list for slot " .. slot .. " is empty"
     end
+
     if self.config.enable_slave_read then
         if magic_radom_seed then
             index = magic_radom_seed % #serv_list + 1
@@ -345,6 +349,7 @@ local function pick_node(self, serv_list, slot, magic_radom_seed)
         end
         host = serv_list[index].ip
         port = serv_list[index].port
+
         --cluster slots will always put the master node as first
         if index > 1 then
             slave = true
@@ -361,9 +366,7 @@ local function pick_node(self, serv_list, slot, magic_radom_seed)
     return host, port, slave
 end
 
-
 local ask_host_and_port = {}
-
 
 local function parse_ask_signal(res)
     --ask signal sample:ASK 12191 127.0.0.1:7008, so we need to parse and get 127.0.0.1, 7008
@@ -375,6 +378,7 @@ local function parse_ask_signal(res)
             end
             return matched[1], matched[2]
         end
+
         if type(res) == "table" then
             for i = 1, #res do
                 if type(res[i]) == "string" and string.sub(res[i], 1, 3) == "ASK" then
@@ -389,7 +393,6 @@ local function parse_ask_signal(res)
     end
     return nil, nil
 end
-
 
 local function has_moved_signal(res)
     if res ~= ngx.null then
@@ -408,22 +411,19 @@ local function has_moved_signal(res)
     return false
 end
 
-
 local function handle_command_with_retry(self, target_ip, target_port, asking, cmd, key, ...)
     local config = self.config
-
     key = tostring(key)
     local slot = redis_slot(key)
 
     for k = 1, config.max_redirection or DEFAULT_MAX_REDIRECTION do
-
         if k > 1 then
-            ngx.log(ngx.NOTICE, "handle retry attempts:" .. k .. " for cmd:" .. cmd .. " key:" .. key)
+            ngx.log(ngx.NOTICE, "handle retry attempt " .. k .. " for cmd: " .. cmd .. ", key: " .. key)
         end
 
         local slots = slot_cache[self.config.name]
         if slots == nil or slots[slot] == nil then
-            return nil, "not slots information present, nginx might have never successfully executed cluster(\"slots\")"
+            return nil, "no slots information present, nginx might have never successfully executed cluster(\"slots\")"
         end
         local serv_list = slots[slot].serv_list
 
@@ -447,12 +447,12 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
 
         local redis_client = redis:new()
         redis_client:set_timeouts(config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
-                                  config.send_timeout or DEFAULT_SEND_TIMEOUT,
-                                  config.read_timeout or DEFAULT_READ_TIMEOUT)
+                config.send_timeout or DEFAULT_SEND_TIMEOUT,
+                config.read_timeout or DEFAULT_READ_TIMEOUT)
         local ok, connerr = redis_client:connect(ip, port, self.config.connect_opts)
 
         if ok then
-            local authok, autherr = check_auth(self, redis_client)
+            local _, autherr = check_auth(self, redis_client)
             if autherr then
                 return nil, autherr
             end
@@ -484,38 +484,51 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
 
             if err then
                 if string.sub(err, 1, 5) == "MOVED" then
-                    --ngx.log(ngx.NOTICE, "find MOVED signal, trigger retry for normal commands, cmd:" .. cmd .. " key:" .. key)
-                    --if retry with moved, we will not asking to specific ip,port anymore
-                    release_connection(redis_client, config)
+                    --ngx.log(ngx.NOTICE, "found MOVED signal, trigger retry for normal commands, cmd: " .. cmd .. ", key: " .. key)
+                    local start, _, moved_ip, moved_port = err:find("MOVED%s+%d+%s+([^:]+):(%d+)")
+                    if start and moved_ip == ip and moved_port == tostring(port) then
+                        -- there's some issue with connection returning bad responses continously
+                        -- even though this node is the master of the data.
+                        -- close it instead of returning to pool
+                        local _, close_err = redis_client:close()
+                        if close_err then
+                            ngx.log(ngx.ERR, "close connection failed: ", close_err)
+                            return nil, "failed to close Redis connection!"
+                        end
+                    else
+                        release_connection(redis_client, config)
+                    end
+
+                    --if retry with moved, we will not ask to specific ip,port anymore
                     target_ip = nil
                     target_port = nil
                     self:refresh_slots()
                     need_to_retry = true
-
                 elseif string.sub(err, 1, 3) == "ASK" then
-                    --ngx.log(ngx.NOTICE, "handle asking for normal commands, cmd:" .. cmd .. " key:" .. key)
+                    --ngx.log(ngx.NOTICE, "handle asking for normal commands, cmd: " .. cmd .. ", key: " .. key)
                     release_connection(redis_client, config)
+
                     if asking then
                         --Should not happen after asking target ip,port and still return ask, if so, return error.
-                        return nil, "nested asking redirection occurred, client cannot retry "
+                        return nil, "nested asking redirection occurred, client cannot retry"
                     else
                         local ask_host, ask_port = parse_ask_signal(err)
 
                         if ask_host ~= nil and ask_port ~= nil then
                             return handle_command_with_retry(self, ask_host, ask_port, true, cmd, key, ...)
                         else
-                            return nil, " cannot parse ask redirection host and port: msg is " .. err
+                            return nil, "cannot parse ask redirection host and port: msg is " .. err
                         end
                     end
-
                 elseif string.sub(err, 1, 11) == "CLUSTERDOWN" then
-                    return nil, "Cannot executing command, cluster status is failed!"
+                    return nil, "cannot execute command, cluster status is failed!"
                 else
                     --There might be node fail, we should also refresh slot cache
                     self:refresh_slots()
                     return nil, err
                 end
             end
+
             if not need_to_retry then
                 release_connection(redis_client, config)
                 return res, err
@@ -529,15 +542,14 @@ local function handle_command_with_retry(self, target_ip, target_port, asking, c
             end
         end
     end
-    return nil, "failed to execute command, reaches maximum redirection attempts"
+    return nil, "failed to execute command, reached maximum redirection attempts"
 end
 
-
 local function generate_magic_seed(self)
-    --For pipeline, We don't want request to be forwarded to all channels, eg. if we have 3*3 cluster(3 master 2 replicas) we
-    --alway want pick up specific 3 nodes for pipeline requests, instead of 9.
-    --Currently we simply use (num of allnode)%count as a randomly fetch. Might consider a better way in the future.
-    -- use the dynamic serv_list instead of the static config serv_list
+    -- For pipeline, we don't want request to be forwarded to all channels, e.g. if we have 3*3 cluster(3 master 2 replicas)
+    -- we always want pick up specific 3 nodes for pipeline requests, instead of 9.
+    -- Currently we simply use (num of allnode)%count as a randomly fetch. Might consider a better way in the future.
+    -- Use the dynamic serv_list instead of the static config serv_list
     local nodeCount = #slot_cache[self.config.name .. "serv_list"].serv_list
     return math.random(nodeCount)
 end
@@ -547,8 +559,9 @@ local function _do_cmd_master(self, cmd, key, ...)
     for _, master in ipairs(master_nodes) do
         local redis_client = redis:new()
         redis_client:set_timeouts(self.config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
-                                  self.config.send_timeout or DEFAULT_SEND_TIMEOUT,
-                                  self.config.read_timeout or DEFAULT_READ_TIMEOUT)
+                self.config.send_timeout or DEFAULT_SEND_TIMEOUT,
+                self.config.read_timeout or DEFAULT_READ_TIMEOUT)
+
         local ok, err = redis_client:connect(master.ip, master.port, self.config.connect_opts)
         if ok then
             _, err = redis_client[cmd](redis_client, key, ...)
@@ -578,10 +591,8 @@ local function _do_cmd(self, cmd, key, ...)
         return _do_cmd_master(self, cmd, key, ...)
     end
 
-    local res, err = handle_command_with_retry(self, nil, nil, false, cmd, key, ...)
-    return res, err
+    return handle_command_with_retry(self, nil, nil, false, cmd, key, ...)
 end
-
 
 local function construct_final_pipeline_resp(self, node_res_map, node_req_map)
     --construct final result with origin index
@@ -590,6 +601,7 @@ local function construct_final_pipeline_resp(self, node_res_map, node_req_map)
         local reqs = node_req_map[k].reqs
         local res = v
         local need_to_fetch_slots = true
+
         for i = 1, #reqs do
             --deal with redis cluster ask redirection
             local ask_host, ask_port = parse_ask_signal(res[i])
@@ -604,7 +616,7 @@ local function construct_final_pipeline_resp(self, node_res_map, node_req_map)
             elseif has_moved_signal(res[i]) then
                 --ngx.log(ngx.NOTICE, "handle moved signal for cmd:" .. reqs[i]["cmd"] .. " key:" .. reqs[i]["key"])
                 if need_to_fetch_slots then
-                    -- if there is multiple signal for moved, we just need to fetch slot cache once, and do retry.
+                    -- if there are multiple signals for moved, we just need to fetch slot cache once, and do retry.
                     self:refresh_slots()
                     need_to_fetch_slots = false
                 end
@@ -622,7 +634,6 @@ local function construct_final_pipeline_resp(self, node_res_map, node_req_map)
     return finalret
 end
 
-
 local function has_cluster_fail_signal_in_pipeline(res)
     for i = 1, #res do
         if res[i] ~= ngx.null and type(res[i]) == "table" then
@@ -636,16 +647,14 @@ local function has_cluster_fail_signal_in_pipeline(res)
     return false
 end
 
-
 function _M.init_pipeline(self)
     self._reqs = {}
 end
 
-
 function _M.commit_pipeline(self)
     local _reqs = rawget(self, "_reqs")
-
-    if not _reqs or #_reqs == 0 then return
+    if not _reqs or #_reqs == 0 then
+        return nil, "no pipeline"
     end
 
     self._reqs = nil
@@ -653,11 +662,10 @@ function _M.commit_pipeline(self)
 
     local slots = slot_cache[config.name]
     if slots == nil then
-        return nil, "not slots information present, nginx might have never successfully executed cluster(\"slots\")"
+        return nil, "no slots information present, nginx might have never successfully executed cluster(\"slots\")"
     end
 
     local node_res_map = {}
-
     local node_req_map = {}
     local magicRandomPickupSeed = generate_magic_seed(self)
 
@@ -669,14 +677,14 @@ function _M.commit_pipeline(self)
         local key = _reqs[i].key
         local slot = redis_slot(tostring(key))
         if slots[slot] == nil then
-            return nil, "not slots information present, nginx might have never successfully executed cluster(\"slots\")"
+            return nil, "no slots information present, nginx might have never successfully executed cluster(\"slots\")"
         end
         local slot_item = slots[slot]
 
         local ip, port, slave, err = pick_node(self, slot_item.serv_list, slot, magicRandomPickupSeed)
         if err then
             -- We must empty local reference to slots cache, otherwise there will be memory issue while
-            -- coroutine swich happens(eg. ngx.sleep, cosocket), very important!
+            -- coroutine switch happens (e.g. ngx.sleep, cosocket), very important!
             slots = nil
             self:refresh_slots()
             return nil, err
@@ -692,7 +700,7 @@ function _M.commit_pipeline(self)
     end
 
     -- We must empty local reference to slots cache, otherwise there will be memory issue while
-    -- coroutine swich happens(eg. ngx.sleep, cosocket), very important!
+    -- coroutine switch happens (e.g. ngx.sleep, cosocket), very important!
     slots = nil
 
     for k, v in pairs(node_req_map) do
@@ -702,22 +710,22 @@ function _M.commit_pipeline(self)
         local slave = v.slave
         local redis_client = redis:new()
         redis_client:set_timeouts(config.connect_timeout or DEFAULT_CONNECTION_TIMEOUT,
-                                  config.send_timeout or DEFAULT_SEND_TIMEOUT,
-                                  config.read_timeout or DEFAULT_READ_TIMEOUT)
+                config.send_timeout or DEFAULT_SEND_TIMEOUT,
+                config.read_timeout or DEFAULT_READ_TIMEOUT)
         local ok, err = redis_client:connect(ip, port, self.config.connect_opts)
 
         if ok then
-            local authok, autherr = check_auth(self, redis_client)
+            local _, autherr = check_auth(self, redis_client)
             if autherr then
                 return nil, autherr
             end
 
             if slave then
                 --set readonly
-                local ok, err = redis_client:readonly()
-                if not ok then
+                local readonly_ok, readonly_err = redis_client:readonly()
+                if not readonly_ok then
                     self:refresh_slots()
-                    return nil, err
+                    return nil, readonly_err
                 end
             end
 
@@ -734,22 +742,23 @@ function _M.commit_pipeline(self)
                     redis_client[req.cmd](redis_client, req.key)
                 end
             end
-            local res, err = redis_client:commit_pipeline()
-            if err then
-                --There might be node fail, we should also refresh slot cache
+
+            local res, commit_err = redis_client:commit_pipeline()
+            if commit_err then
+                --There might be a node fail, we should also refresh slot cache
                 self:refresh_slots()
-                return nil, err .. " return from " .. tostring(ip) .. ":" .. tostring(port)
+                return nil, commit_err .. " returned from " .. tostring(ip) .. ":" .. tostring(port)
             end
 
             if has_cluster_fail_signal_in_pipeline(res) then
-                return nil, "Cannot executing pipeline command, cluster status is failed!"
+                return nil, "cannot execute pipeline command, cluster status is failed!"
             end
             release_connection(redis_client, config)
             node_res_map[k] = res
         else
-            --There might be node fail, we should also refresh slot cache
+            --There might be a node fail, we should also refresh slot cache
             self:refresh_slots()
-            return nil, err .. "pipeline commit failed while connecting to " .. tostring(ip) .. ":" .. tostring(port)
+            return nil, err .. " pipeline commit failed while connecting to " .. tostring(ip) .. ":" .. tostring(port)
         end
     end
 
@@ -758,37 +767,36 @@ function _M.commit_pipeline(self)
     if not err then
         return final_res
     else
-        return nil, err .. " failed to construct final pipeline result "
+        return nil, err .. " failed to construct final pipeline result"
     end
 end
-
 
 function _M.cancel_pipeline(self)
     self._reqs = nil
 end
 
 local function _do_eval_cmd(self, cmd, ...)
---[[
-eval command usage:
-eval(script, 1, key, arg1, arg2 ...)
-eval(script, 0, arg1, arg2 ...)
-]]
-    local args = {...}
+    --[[
+    eval command usage:
+    eval(script, 1, key, arg1, arg2 ...)
+    eval(script, 0, arg1, arg2 ...)
+    ]]
+    local args = { ... }
     local keys_num = args[2]
     if type(keys_num) ~= "number" then
-        return nil, "Cannot execute eval without keys number"
+        return nil, "cannot execute eval without keys number"
     end
     if keys_num > 1 then
-        return nil, "Cannot execute eval with more than one keys for redis cluster"
+        return nil, "cannot execute eval with more than one keys for redis cluster"
     end
     local key = args[3] or "no_key"
     return _do_cmd(self, cmd, key, ...)
 end
+
 -- dynamic cmd
 setmetatable(_M, {
     __index = function(_, cmd)
-        local method =
-        function(self, ...)
+        local method = function(self, ...)
             if cmd == "eval" or cmd == "evalsha" then
                 return _do_eval_cmd(self, cmd, ...)
             else
@@ -796,8 +804,7 @@ setmetatable(_M, {
             end
         end
 
-        -- cache the lazily generated method in our
-        -- module table
+        -- cache the lazily generated method in our module table
         _M[cmd] = method
         return method
     end


### PR DESCRIPTION
1. Fix weird case where redis connection returns MOVED response to the same node from which the data was fetched- closing the TCP socket resolves the issue.
2. Fix a potential connection leak in case of node failure or cluster down.
3. Fix ASK redirection resulting in an extra redirection attempt.
4. Fix key in case of "eval" or "evalsha" command with 0 keys.
5. Fix handling of failure to parse ASK signal when it came from a pipeline result.
6. Refactor, reformat, fix typos.